### PR TITLE
Wire Telegram userbot handlers and dual Doodstream uploads

### DIFF
--- a/telegram_userbot/handlers/admin_handler.py
+++ b/telegram_userbot/handlers/admin_handler.py
@@ -151,7 +151,7 @@ Use `/sync` to manually sync Doodstream
                 return
             
             # Check if group already exists
-            existing = await self.supabase.client.table('premium_groups').select('*').eq('chat_id', chat_id).execute()
+            existing = self.supabase.client.table('premium_groups').select('*').eq('chat_id', chat_id).execute()
             
             if existing.data:
                 await message.reply_text(f"⚠️ Group {chat_id} is already in premium groups list")

--- a/telegram_userbot/handlers/auth_handler.py
+++ b/telegram_userbot/handlers/auth_handler.py
@@ -32,11 +32,12 @@ class AuthHandler:
             # Generate unique linking code
             link_code = self._generate_link_code()
             
-            # Store linking code in database
+            # Store linking code in database along with chat ID
             code_data = {
                 'code': link_code,
                 'telegram_user_id': user.id,
-                'telegram_username': user.username or user.first_name
+                'telegram_username': user.username or user.first_name,
+                'telegram_chat_id': message.chat.id,
             }
             
             result = self.supabase.client.table('telegram_link_codes').insert(code_data).execute()

--- a/telegram_userbot/systemd/telegram-userbot.service
+++ b/telegram_userbot/systemd/telegram-userbot.service
@@ -6,8 +6,8 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-User=%i
-Group=%i
+User=telegram-userbot
+Group=telegram-userbot
 WorkingDirectory=%h/telegram_userbot
 ExecStart=%h/telegram_userbot/run_userbot.sh
 Restart=always


### PR DESCRIPTION
## Summary
- initialize Supabase-backed handlers for uploads, admin, and account linking
- auto-upload media and expose admin and /link commands
- invoke dual Doodstream uploads and store both regular and premium file codes
- store chat id during linking and run service under telegram-userbot user

## Testing
- `python -m py_compile telegram_userbot/main.py telegram_userbot/handlers/*.py telegram_userbot/utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0a7d386b88322b6d8a63524198290